### PR TITLE
fix: parseCliArgs fails under Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@skypilot/parsifal",
   "version": "0.2.0",
   "private": false,
+  "engines": {
+    "node": ">=10"
+  },
   "description": "Intelligent and flexible parser for command-line arguments",
   "keywords": [
     "cli",

--- a/src/lib/functions/object/__tests__/fromEntries.unit.test.ts
+++ b/src/lib/functions/object/__tests__/fromEntries.unit.test.ts
@@ -1,0 +1,39 @@
+import { fromEntries } from '../fromEntries';
+
+describe('fromEntries(entries)', () => {
+  it('should create an object from the entries and return it', () => {
+    const entries = [
+      ['a', 1],
+      ['b', 2],
+    ] as const;
+
+    const obj = fromEntries(entries);
+
+    const expected = { a: 1, b: 2 };
+    expect(obj).toStrictEqual(expected);
+  });
+
+  it('can use numbers as keys', () => {
+    const entries = [
+      [1, 'a'],
+      [2, 'b'],
+    ] as const;
+
+    const obj = fromEntries(entries);
+
+    const expected = { '1': 'a', '2': 'b' };
+    expect(obj).toStrictEqual(expected);
+  });
+
+  it('can use symbols as keys', () => {
+    const entries = [
+      [Symbol.for('1'), 1],
+      [Symbol.for('2'), 2],
+    ] as const;
+
+    const obj = fromEntries(entries);
+
+    const expected = { [Symbol.for('1')]: 1, [Symbol.for('2')]: 2 };
+    expect(obj).toStrictEqual(expected);
+  });
+});

--- a/src/lib/functions/object/fromEntries.ts
+++ b/src/lib/functions/object/fromEntries.ts
@@ -1,0 +1,14 @@
+/* Ponyfill for `Object.fromEntries` */
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export function fromEntries<T = any>(entries: Iterable<readonly [string | number | symbol, T]>): { [k: string]: T } {
+  if (Object.fromEntries) {
+    return Object.fromEntries(entries);
+  }
+  return [...entries].reduce((obj, [key, value]) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    obj[key] = value
+    return obj;
+  }, {} as { [k: string]: T });
+}

--- a/src/parseCliArgs/index.ts
+++ b/src/parseCliArgs/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import type { Integer } from '@skypilot/common-types';
+import { fromEntries } from 'src/lib/functions/object/fromEntries';
 import { initialParse } from '../initialParse';
 import type {
   Argument,
@@ -123,6 +124,6 @@ export function parseCliArgs(
   return {
     _positional: positionalArgs,
     _unparsed: unparsedArgs,
-    ...Object.fromEntries(argsMapToEntries(argsMap)),
+    ...fromEntries(argsMapToEntries(argsMap)),
   };
 }


### PR DESCRIPTION
`parseCliArgs` was failing under Node 10 because `Object.fromEntries` is not supported in that version of node.

Fixed by adding a ponyfill function, `fromEntries`.

Also added an explicit required of Node >= 10 to the package file.