### PR TITLE
Features: Support integer & string arrays, range validation & custom validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@skypilot/common-types": "2.2.2",
-    "@skypilot/toolchain": "^5.2.3",
-    "@types/minimist": "^1.2.1"
+    "@skypilot/common-types": "2.3.0",
+    "@skypilot/toolchain": "^5.2.3"
   },
   "publishConfig": {
     "access": "restricted"

--- a/src/parseCliArgs/__tests__/parseCliArgs.unit.test.ts
+++ b/src/parseCliArgs/__tests__/parseCliArgs.unit.test.ts
@@ -216,4 +216,46 @@ describe('parseCliArgs() - arguments', () => {
     };
     expect(args).toStrictEqual(expectedArgs);
   });
+
+  it("if `valueType: 'stringArray`, should convert the value to a string array", () => {
+    const definitions: DefinitionsMap = {
+      named: [
+        { name: 'alphanumericStringArray', valueType: 'stringArray' },
+        { name: 'numericStringArray', valueType: 'stringArray' },
+      ],
+    };
+    const options = {
+      args: toArgs('--numericStringArray=1,2 --alphanumericStringArray=a,1'),
+    };
+
+    const args = parseCliArgs(definitions, options);
+
+    const expectedArgs = {
+      _positional: [],
+      _unparsed: [],
+      alphanumericStringArray: ['a', '1'],
+      numericStringArray: ['1', '2'],
+    };
+    expect(args).toStrictEqual(expectedArgs);
+  });
+
+  it("if `valueType: 'integerArray`, should convert the value to an integer array", () => {
+    const definitions: DefinitionsMap = {
+      named: [
+        { name: 'integerArray', valueType: 'integerArray' },
+      ],
+    };
+    const options = {
+      args: toArgs('--integerArray=1,2'),
+    };
+
+    const args = parseCliArgs(definitions, options);
+
+    const expectedArgs = {
+      _positional: [],
+      _unparsed: [],
+      integerArray: [1, 2],
+    };
+    expect(args).toStrictEqual(expectedArgs);
+  });
 });

--- a/src/parseCliArgs/_types/index.ts
+++ b/src/parseCliArgs/_types/index.ts
@@ -2,12 +2,12 @@ import type { Integer, RequireProps } from '@skypilot/common-types';
 
 export interface Argument {
   definition: ArgumentDefinition;
-  value: ArgumentValue;
+  value: ArgumentValue | ArgumentValue[];
 }
 
 export interface ArgumentDefV1 {
   aliases?: string[];
-  defaultValue?: ArgumentValue;
+  defaultValue?: ArgumentValue | ArgumentValue[];
   name?: string;
   positional?: boolean;
   required?: boolean;
@@ -23,14 +23,14 @@ export type ArgumentDefinition = RequireProps<ArgumentDefV1, 'name'>
 export type ArgumentInput = ArgumentDefinition | string;
 
 export interface ArgumentsMap {
-  [key: string]: ArgumentValue;
+  [key: string]: ArgumentValue | ArgumentValue[];
 }
 
-export type ArgumentValue = LiteralValue | undefined
+export type ArgumentValue = LiteralValue | undefined;
 
 export interface EchoOptions {
   // If true, echo parsed values to the console
-  echoIf?: boolean | ((argValuesMap: Map<string, ArgumentValue>) => unknown);
+  echoIf?: boolean | ((argValuesMap: Map<string, ArgumentValue | ArgumentValue[]>) => unknown);
   echoUndefined?: boolean;
 }
 
@@ -66,6 +66,6 @@ export interface ValidationException {
   identifiers: string[];
 }
 
-export type ValueType = 'boolean' | 'integer' | 'string' | 'number';
+export type ValueType = 'boolean' | 'integer' | 'integerArray' | 'string' | 'stringArray' | 'number';
 
 export type ValueValidator<T = any> = (value: T) => boolean | { errors?: string[]; ok: boolean };

--- a/src/parseCliArgs/_types/index.ts
+++ b/src/parseCliArgs/_types/index.ts
@@ -1,4 +1,4 @@
-import type { RequireProps } from '@skypilot/common-types';
+import type { Integer, RequireProps } from '@skypilot/common-types';
 
 export interface Argument {
   definition: ArgumentDefinition;
@@ -12,6 +12,7 @@ export interface ArgumentDefV1 {
   positional?: boolean;
   required?: boolean;
   validate?: ValueValidator;
+  validRange?: Integer[];
   validValues?: ArgumentValue[];
   valueLabel?: string;
   valueType?: ValueType;
@@ -59,7 +60,7 @@ export type PositionalArgumentDef = ArgumentDefinition & {
 export type PositionalArgDefInput = PositionalArgumentDef | string;
 
 export interface ValidationException {
-  code?: 'badDefinition' | 'badValue' | 'missing' | 'unlistedValue' | 'wrongType';
+  code?: 'badDefinition' | 'badValue' | 'missing' | 'outOfRangeValue' | 'unlistedValue' | 'wrongType';
   level?: 'warning' | 'error';
   message: string;
   identifiers: string[];

--- a/src/parseCliArgs/_types/index.ts
+++ b/src/parseCliArgs/_types/index.ts
@@ -1,6 +1,4 @@
-import { RequireProps } from '@skypilot/common-types';
-
-type Validator = (arg: string) => boolean;
+import type { RequireProps } from '@skypilot/common-types';
 
 export interface Argument {
   definition: ArgumentDefinition;
@@ -13,7 +11,7 @@ export interface ArgumentDefV1 {
   name?: string;
   positional?: boolean;
   required?: boolean;
-  validator?: Validator;
+  validate?: ValueValidator;
   validValues?: ArgumentValue[];
   valueLabel?: string;
   valueType?: ValueType;
@@ -54,17 +52,19 @@ export interface NamedArgumentDef extends RequireProps<ArgumentDefV1, 'name'> {
 
 export type NamedArgDefInput = NamedArgumentDef | string;
 
-export interface PositionalArgumentDef extends ArgumentDefinition {
+export type PositionalArgumentDef = ArgumentDefinition & {
   positional?: true;
 }
 
 export type PositionalArgDefInput = PositionalArgumentDef | string;
 
 export interface ValidationException {
-  code?: 'badDefinition' | 'missing' | 'unlistedValue' | 'wrongType';
+  code?: 'badDefinition' | 'badValue' | 'missing' | 'unlistedValue' | 'wrongType';
   level?: 'warning' | 'error';
   message: string;
   identifiers: string[];
 }
 
 export type ValueType = 'boolean' | 'integer' | 'string' | 'number';
+
+export type ValueValidator<T = any> = (value: T) => boolean | { errors?: string[]; ok: boolean };

--- a/src/parseCliArgs/argsMapToEntries.ts
+++ b/src/parseCliArgs/argsMapToEntries.ts
@@ -1,6 +1,6 @@
 import { Argument, ArgumentValue } from './_types';
 
-export function argsMapToEntries(argsMap: Map<string, Argument>): Array<[string, ArgumentValue]> {
+export function argsMapToEntries(argsMap: Map<string, Argument>): Array<[string, ArgumentValue | ArgumentValue[]]> {
   const entries = Array.from(argsMap.entries());
   return entries.map(([name, argument]) => [name, argument.value]);
 }

--- a/src/parseCliArgs/index.ts
+++ b/src/parseCliArgs/index.ts
@@ -23,6 +23,8 @@ import { validateArgDefs } from './validators/validateArgDefs';
 import { validateOptionNames } from './validators/validateOptionNames';
 import { validatePositionalArgDefs } from './validators/validatePositionalArgDefs';
 
+export type { ValueValidator } from './_types';
+
 type NamedArgsResult = {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   [key: string]: any;

--- a/src/parseCliArgs/mapArgs.ts
+++ b/src/parseCliArgs/mapArgs.ts
@@ -39,11 +39,27 @@ export function mapArgs(
   });
 
   namedArgDefs.forEach(definition => {
-    const { defaultValue, name } = definition;
-    argsMap.set(name, {
-      definition,
-      value: getOrDefault(initialParsedArgs, name, defaultValue) as ArgumentValue | undefined,
-    });
+    const { defaultValue, name, valueType } = definition;
+    const convertedValue = (() => {
+      const enteredValue = getOrDefault(initialParsedArgs, name, undefined);
+      switch (valueType) {
+        case 'stringArray':
+          console.log('enteredValue:', enteredValue);
+          return typeof enteredValue === 'undefined' ? undefined
+            : typeof enteredValue === 'string' ? enteredValue.split(',')
+              : [`${enteredValue}`];
+        case 'integerArray':
+          return typeof enteredValue === 'undefined' ? undefined
+            : typeof enteredValue === 'number' ? [enteredValue]
+              : typeof enteredValue === 'string' ? enteredValue.split(',').map(integerString => parseInt(integerString, 10))
+                : [`${enteredValue}`];
+        default:
+          return enteredValue;
+      }
+    })();
+    const value = typeof convertedValue === 'undefined' ? defaultValue : convertedValue;
+    const argument: Argument = { definition, value };
+    argsMap.set(name, argument);
   });
 
   if (mapAllNamedArgs) {

--- a/src/parseCliArgs/utils/__tests__/toEchoParams.unit.test.ts
+++ b/src/parseCliArgs/utils/__tests__/toEchoParams.unit.test.ts
@@ -29,7 +29,7 @@ describe('toEchoParams()', () => {
   });
 
   it('if `options: echoIf` is a function, should return `shouldEcho: [evaluated function]`', () => {
-    const echoIfVerbose = (argsDict: Map<string, ArgumentValue>): boolean | undefined => !!argsDict.get('verbose');
+    const echoIfVerbose = (argsDict: Map<string, ArgumentValue | ArgumentValue[]>): boolean | undefined => !!argsDict.get('verbose');
 
     const echoParams = toEchoParams(argValuesMap, { echoIf: echoIfVerbose });
     expect(echoParams).toStrictEqual({ echoUndefined: false, shouldEcho: true });

--- a/src/parseCliArgs/utils/formatArgsForEcho.ts
+++ b/src/parseCliArgs/utils/formatArgsForEcho.ts
@@ -5,7 +5,7 @@ interface FormatArgsForEchoOptions {
 }
 
 export function formatArgsForEcho(
-  argValuesMap: Map<string, ArgumentValue>,
+  argValuesMap: Map<string, ArgumentValue | ArgumentValue[]>,
   unresolvedPositionalArgs: Array<boolean | number | string>,
   options: FormatArgsForEchoOptions = {}
 ): string[] {

--- a/src/parseCliArgs/utils/toEchoParams.ts
+++ b/src/parseCliArgs/utils/toEchoParams.ts
@@ -2,7 +2,7 @@ import type { ArgumentValue, EchoOptions, EchoParams } from '../_types';
 
 // Given an arguments map and options, return a corresponding `EchoParams` object
 export function toEchoParams(
-  argValuesMap: Map<string, ArgumentValue>,
+  argValuesMap: Map<string, ArgumentValue | ArgumentValue[]>,
   options: EchoOptions | boolean = false
 ): EchoParams {
   if (typeof options === 'boolean') {

--- a/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
@@ -1,4 +1,4 @@
-import { ValidationException } from '../../_types';
+import type { Argument, ValidationException } from 'src/parseCliArgs/_types';
 import { validateConstrainedArgs } from '../validateConstrainedArgs';
 
 describe('validateConstrainedArgs()', () => {
@@ -15,9 +15,16 @@ describe('validateConstrainedArgs()', () => {
   });
 
   it('should return no exceptions if all constrained args are satisfied', () => {
-    const argsMap = new Map([
+    const argsMap = new Map<string, Argument>([
       ['uncon1', { definition: { name: 'uncon1' }, value: undefined }],
       ['con2', { definition: { name: 'con2', validValues: [1] }, value: 1 }],
+      ['simpleValidate', {
+        definition: {
+          name: 'simpleValidate',
+          validate: value => typeof value === 'number' && value < 2,
+        },
+        value: 1,
+      }],
     ]);
 
     const exceptions = validateConstrainedArgs(argsMap);
@@ -27,11 +34,15 @@ describe('validateConstrainedArgs()', () => {
   });
 
   it('should return exceptions for each invalid argument', () => {
+    const detailedValidate = (value: number): { ok: boolean; errors?: string[] } => value < 2
+      ? { ok: false, errors: [`${value} < 2`] }
+      : { ok: true };
     const argsMap = new Map([
       ['con1', { definition: { name: 'con1', validValues: [1] }, value: 2 }],
       ['con2', { definition: { name: 'con2', validValues: [1] }, value: 1 }],
       ['con3', { definition: { name: 'con3', validValues: ['1'] }, value: 1 }],
       ['uncon4', { definition: { name: 'uncon4' }, value: undefined }],
+      ['detailedValidate', { definition: { name: 'detailedValidate', validate: detailedValidate }, value: 1 }],
     ]);
 
     const exceptions = validateConstrainedArgs(argsMap);
@@ -49,7 +60,13 @@ describe('validateConstrainedArgs()', () => {
         message: "Invalid value for 'con3': Expected one of '1', got '1'",
         identifiers: ['con3'],
       },
+      {
+        code: 'badValue',
+        level: 'error',
+        message: "Invalid value for 'detailedValidate': 1 < 2",
+        identifiers: ['detailedValidate'],
+      },
     ];
-    expect(exceptions).toEqual(expected);
+    expect(exceptions).toStrictEqual(expected);
   });
 });

--- a/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
@@ -43,6 +43,7 @@ describe('validateConstrainedArgs()', () => {
       ['con3', { definition: { name: 'con3', validValues: ['1'] }, value: 1 }],
       ['uncon4', { definition: { name: 'uncon4' }, value: undefined }],
       ['detailedValidate', { definition: { name: 'detailedValidate', validate: detailedValidate }, value: 1 }],
+      ['rangeValidate', { definition: { name: 'rangeValidate', validRange: [2, 3] }, value: 1 }],
     ]);
 
     const exceptions = validateConstrainedArgs(argsMap);
@@ -65,6 +66,12 @@ describe('validateConstrainedArgs()', () => {
         level: 'error',
         message: "Invalid value for 'detailedValidate': 1 < 2",
         identifiers: ['detailedValidate'],
+      },
+      {
+        code: 'outOfRangeValue',
+        level: 'error',
+        message: "Invalid value for 'rangeValidate': Valid range is 2-3",
+        identifiers: ['rangeValidate'],
       },
     ];
     expect(exceptions).toStrictEqual(expected);

--- a/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
@@ -38,12 +38,13 @@ describe('validateConstrainedArgs()', () => {
       ? { ok: false, errors: [`${value} < 2`] }
       : { ok: true };
     const argsMap = new Map([
-      ['con1', { definition: { name: 'con1', validValues: [1] }, value: 2 }],
+      ['con1', { definition: { name: 'con1', validValues: [1, 2] }, value: 3 }],
       ['con2', { definition: { name: 'con2', validValues: [1] }, value: 1 }],
-      ['con3', { definition: { name: 'con3', validValues: ['1'] }, value: 1 }],
+      ['con3', { definition: { name: 'con3', validValues: ['a', 'b'] }, value: 1 }],
       ['uncon4', { definition: { name: 'uncon4' }, value: undefined }],
       ['detailedValidate', { definition: { name: 'detailedValidate', validate: detailedValidate }, value: 1 }],
       ['rangeValidate', { definition: { name: 'rangeValidate', validRange: [2, 3] }, value: 1 }],
+      ['arrayRangeValidate', { definition: { name: 'arrayRangeValidate', validRange: [1, 2] }, value: [3, 4] }]
     ]);
 
     const exceptions = validateConstrainedArgs(argsMap);
@@ -52,13 +53,13 @@ describe('validateConstrainedArgs()', () => {
       {
         code: 'unlistedValue',
         level: 'error',
-        message: "Invalid value for 'con1': Expected one of '1', got '2'",
+        message: "Invalid value 3 for 'con1'. Allowed values: 1, 2",
         identifiers: ['con1'],
       },
       {
         code: 'unlistedValue',
         level: 'error',
-        message: "Invalid value for 'con3': Expected one of '1', got '1'",
+        message: "Invalid value 1 for 'con3'. Allowed values: 'a', 'b'",
         identifiers: ['con3'],
       },
       {
@@ -70,8 +71,20 @@ describe('validateConstrainedArgs()', () => {
       {
         code: 'outOfRangeValue',
         level: 'error',
-        message: "Invalid value for 'rangeValidate': Valid range is 2-3",
+        message: "Invalid value 1 for 'rangeValidate': Valid range is 2-3",
         identifiers: ['rangeValidate'],
+      },
+      {
+        code: 'outOfRangeValue',
+        level: 'error',
+        message: "Invalid value 3 for 'arrayRangeValidate': Valid range is 1-2",
+        identifiers: ['arrayRangeValidate'],
+      },
+      {
+        code: 'outOfRangeValue',
+        level: 'error',
+        message: "Invalid value 4 for 'arrayRangeValidate': Valid range is 1-2",
+        identifiers: ['arrayRangeValidate'],
       },
     ];
     expect(exceptions).toStrictEqual(expected);

--- a/src/parseCliArgs/validators/disallowUnlistedDefault.ts
+++ b/src/parseCliArgs/validators/disallowUnlistedDefault.ts
@@ -4,17 +4,27 @@ export function disallowUnlistedDefault(
   argDefs: ArgumentDefinition[]
 ): ValidationException[] {
   return argDefs.reduce((accExceptions, argDef) => {
-    if (
-      argDef.validValues
-        && argDef.defaultValue !== undefined
-        && !argDef.validValues.includes(argDef.defaultValue)
-    ) {
+    const { defaultValue, validValues } = argDef;
+
+    if (!validValues || typeof defaultValue === 'undefined') {
+      return accExceptions;
+    }
+
+    const defaultValues = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
+    const invalidValues = defaultValues.filter((value: any) => !validValues.includes(value));
+
+    if (invalidValues.length > 0) {
       return [
         ...accExceptions,
         {
           code: 'badDefinition',
           level: 'error',
-          message: `Bad definition for ${argDef.name}: The default value is not one of the valid values`,
+          message: [
+            `Bad definition for ${argDef.name}`,
+            invalidValues.length === 1
+              ? 'The default value is not one of the valid values'
+              : 'Some default values are not among the valid values',
+          ].join(': '),
           identifiers: [argDef.name],
         },
       ];

--- a/src/parseCliArgs/validators/hasCorrectType.ts
+++ b/src/parseCliArgs/validators/hasCorrectType.ts
@@ -1,7 +1,19 @@
 import { ArgumentValue, ValueType } from '../_types';
 
-export function hasCorrectType(valueType: ValueType, value: ArgumentValue): boolean {
-  return valueType === 'integer'
-    ? typeof value === 'number' && value % 1 === 0
-    : typeof value === valueType;
+function isInteger(value: unknown): boolean {
+  return typeof value === 'number' && value % 1 === 0;
+}
+
+
+export function hasCorrectType(valueType: ValueType, value: ArgumentValue | ArgumentValue[]): boolean {
+  switch (valueType) {
+    case 'integer':
+      return isInteger(value);
+    case 'integerArray':
+      return Array.isArray(value) && value.every(item => isInteger(item));
+    case 'stringArray':
+      return Array.isArray(value) && value.every(item => typeof item === 'string');
+    default:
+      return typeof value === valueType;
+  }
 }

--- a/src/parseCliArgs/validators/validateConstrainedArgs.ts
+++ b/src/parseCliArgs/validators/validateConstrainedArgs.ts
@@ -1,14 +1,16 @@
 import { Argument, ValidationException } from '../_types';
 import { validateConstrainedValue } from './validateConstrainedValue';
+import { validateCustom } from './validateCustom';
 
 export function validateConstrainedArgs(argsMap: Map<string, Argument>): ValidationException[] {
   return Array.from(argsMap.entries())
-    .filter(([_name, argument]) => !!argument.definition.validValues)
+    .filter(([_name, argument]) => !!argument.definition.validValues || !!argument.definition.validate)
     .reduce((accExceptions, [_name, argument]) => {
       const { definition, value } = argument;
       return [
         ...accExceptions,
         ...validateConstrainedValue(value, definition),
+        ...validateCustom(value, definition),
       ];
     }, [] as ValidationException[]);
 }

--- a/src/parseCliArgs/validators/validateConstrainedArgs.ts
+++ b/src/parseCliArgs/validators/validateConstrainedArgs.ts
@@ -1,16 +1,22 @@
 import { Argument, ValidationException } from '../_types';
 import { validateConstrainedValue } from './validateConstrainedValue';
 import { validateCustom } from './validateCustom';
+import { validateRange } from './validateRange';
 
 export function validateConstrainedArgs(argsMap: Map<string, Argument>): ValidationException[] {
   return Array.from(argsMap.entries())
-    .filter(([_name, argument]) => !!argument.definition.validValues || !!argument.definition.validate)
+    .filter(([_name, argument]) => !!(
+      argument.definition.validate
+      || argument.definition.validRange
+      || argument.definition.validValues
+    ))
     .reduce((accExceptions, [_name, argument]) => {
       const { definition, value } = argument;
       return [
         ...accExceptions,
         ...validateConstrainedValue(value, definition),
         ...validateCustom(value, definition),
+        ...validateRange(value, definition),
       ];
     }, [] as ValidationException[]);
 }

--- a/src/parseCliArgs/validators/validateConstrainedValue.ts
+++ b/src/parseCliArgs/validators/validateConstrainedValue.ts
@@ -1,29 +1,40 @@
-import { MaybeReadOnlyArray } from '@skypilot/common-types';
 import { ArgumentDefinition, ArgumentValue, ValidationException } from '../_types';
 
-function isValidConstrainedValue<T>(validValues: MaybeReadOnlyArray<T>, value: T | undefined): boolean {
+function isValidConstrainedValue<T>(validValues: ReadonlyArray<T>, value: T | undefined): boolean {
   return value !== undefined && validValues.includes(value);
 }
 
+function formatValue(value: unknown): string {
+  return typeof value === 'string' ? `'${value}'` : JSON.stringify(value);
+}
+
 export function validateConstrainedValue(
-  value: ArgumentValue, argDef: ArgumentDefinition,
+  value: ArgumentValue | ArgumentValue[], argDef: ArgumentDefinition,
 ): ValidationException[] {
   if (value === undefined) {
     /* An undefined value, if not permitted, will be flagged as a missing required value,
        so it isn't reported as an exception here. */
     return [];
   }
-  if (argDef.validValues?.length) {
-    if (!isValidConstrainedValue(argDef.validValues, value)) {
-      return [{
-        code: 'unlistedValue',
-        level: 'error',
-        message: `Invalid value for '${argDef.name}': Expected one of ${
-          argDef.validValues.map((validValue) => `'${validValue}'`).join(' | ')
-        }, got '${value}'`,
-        identifiers: [argDef.name],
-      }];
-    }
+  const { validValues } = argDef;
+  if (!validValues) {
+    return [];
+  }
+
+  const isValid = Array.isArray(value)
+    ? value.every(item => isValidConstrainedValue(validValues, item))
+    : isValidConstrainedValue(validValues, value);
+
+  if (!isValid) {
+    return [{
+      code: 'unlistedValue',
+      level: 'error',
+      message: `Invalid value ${formatValue(value)} for '${argDef.name}'. Allowed values: ${
+        validValues
+          .map((validValue) => formatValue(validValue)).join(', ')
+      }`,
+      identifiers: [argDef.name],
+    }];
   }
   return [];
 }

--- a/src/parseCliArgs/validators/validateCustom.ts
+++ b/src/parseCliArgs/validators/validateCustom.ts
@@ -1,0 +1,30 @@
+import { ArgumentDefinition, ArgumentValue, ValidationException } from '../_types';
+
+export function validateCustom(
+  value: ArgumentValue, argDef: ArgumentDefinition,
+): ValidationException[] {
+  if (value === undefined) {
+    /* An undefined value, if not permitted, will be flagged as a missing required value,
+       so it isn't reported as an exception here. */
+    return [];
+  }
+  if (argDef.validate) {
+    const validationResult = argDef.validate(value);
+    const resolvedResult = typeof validationResult === 'boolean' ? { ok: validationResult }
+      : validationResult;
+
+    if (!resolvedResult.ok) {
+      const { errors = [] } = resolvedResult;
+      return [{
+        code: 'badValue',
+        level: 'error',
+        message: [
+          `Invalid value for '${argDef.name}'`,
+          ...(errors.length ? [errors.join('; ')] : []),
+        ].join(': '),
+        identifiers: [argDef.name],
+      }];
+    }
+  }
+  return [];
+}

--- a/src/parseCliArgs/validators/validateRange.ts
+++ b/src/parseCliArgs/validators/validateRange.ts
@@ -1,0 +1,33 @@
+import { ArgumentDefinition, ArgumentValue, ValidationException } from '../_types';
+
+export function validateRange(
+  value: ArgumentValue, argDef: ArgumentDefinition,
+): ValidationException[] {
+  if (value === undefined) {
+    /* An undefined value, if not permitted, will be flagged as a missing required value,
+       so it isn't reported as an exception here. */
+    return [];
+  }
+
+  const { validRange } = argDef;
+
+  if (!validRange) {
+    return [];
+  }
+
+  if (validRange.length !== 2) {
+    throw new Error(`Invalid range: ${validRange}`);
+  }
+
+  const [minValue, maxValue] = validRange;
+  if (value >= minValue && value <= maxValue) {
+    return [];
+  }
+
+  return [{
+    code: 'outOfRangeValue',
+    level: 'error',
+    message: `Invalid value for '${argDef.name}': Valid range is ${minValue}-${maxValue}`,
+    identifiers: [argDef.name],
+  }];
+}

--- a/src/parseCliArgs/validators/validateRange.ts
+++ b/src/parseCliArgs/validators/validateRange.ts
@@ -1,9 +1,9 @@
 import { ArgumentDefinition, ArgumentValue, ValidationException } from '../_types';
 
 export function validateRange(
-  value: ArgumentValue, argDef: ArgumentDefinition,
+  value: ArgumentValue | ArgumentValue[], argDef: ArgumentDefinition,
 ): ValidationException[] {
-  if (value === undefined) {
+  if (!Array.isArray(value) && typeof value === 'undefined') {
     /* An undefined value, if not permitted, will be flagged as a missing required value,
        so it isn't reported as an exception here. */
     return [];
@@ -20,14 +20,14 @@ export function validateRange(
   }
 
   const [minValue, maxValue] = validRange;
-  if (value >= minValue && value <= maxValue) {
-    return [];
-  }
+  const values = Array.isArray(value) ? value : [value];
 
-  return [{
-    code: 'outOfRangeValue',
-    level: 'error',
-    message: `Invalid value for '${argDef.name}': Valid range is ${minValue}-${maxValue}`,
-    identifiers: [argDef.name],
-  }];
+  return values
+    .filter(item => typeof item === 'undefined' || item < minValue || item > maxValue)
+    .map(item => ({
+      code: 'outOfRangeValue',
+      level: 'error',
+      message: `Invalid value ${JSON.stringify(item)} for '${argDef.name}': Valid range is ${minValue}-${maxValue}`,
+      identifiers: [argDef.name],
+    }));
 }

--- a/src/parseCliArgs/validators/validateTypedValue.ts
+++ b/src/parseCliArgs/validators/validateTypedValue.ts
@@ -2,7 +2,7 @@ import { ArgumentDefinition, ArgumentValue, ValidationException } from '../_type
 import { hasCorrectType } from './hasCorrectType';
 
 export function validateTypedValue(
-  value: ArgumentValue, argDef: ArgumentDefinition
+  value: ArgumentValue | ArgumentValue[], argDef: ArgumentDefinition
 ): ValidationException[] {
   const { name, valueType } = argDef;
   if (!valueType) {
@@ -14,8 +14,8 @@ export function validateTypedValue(
     return [{
       code: 'wrongType',
       level: 'error',
-      message: `Error: ${valueString} is not a valid value for ${name}`,
-      identifiers: [`'${name}'`],
+      message: `${valueString} is not a valid value for ${name}`,
+      identifiers: [name],
     }];
   }
   return [];

--- a/src/scripts/parse-args.ts
+++ b/src/scripts/parse-args.ts
@@ -4,6 +4,8 @@ const parsedArgs = parseCliArgs({
   named: [
     { name: 'myNamedArg', aliases:  ['n'] },
     { name: 'verbose', valueType: 'boolean' },
+    { name: 'int', valueType: 'integerArray', validRange: [1,2] },
+    { name: 'str', valueType: 'stringArray' },
   ],
   positional: [
     { name: 'positional' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,10 +1555,10 @@
   dependencies:
     babel-plugin-root-import "^6.6.0"
 
-"@skypilot/common-types@2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@skypilot/common-types/-/common-types-2.2.2.tgz#455b2df16a4692e069ce763831750e7db804e33f"
-  integrity sha512-CsQukjSe/73P4H0GRvubP4EHB1Pnhse2NlJcsUVqvw34vky7zMY2779ryXh4d/X8ZzPAlP73nqpl8dd96FKS0w==
+"@skypilot/common-types@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@skypilot/common-types/-/common-types-2.3.0.tgz#d816b5b049e7ebf372138860299bb4e8dcfbf7de"
+  integrity sha512-rfuu3RZRcCEWk1PE4NnvrCAuOIrCvoK6AvbotuPcEQ2m2QbXN4OuE0/5J3FtwakVM7SsNabvWsletN6/oqkM7Q==
 
 "@skypilot/eslint-config-typescript@^1.7.0":
   version "1.7.0"
@@ -1695,11 +1695,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
-"@types/minimist@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
-  integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
 "@types/node@*":
   version "13.13.5"


### PR DESCRIPTION
Improved `parseCliArgs`. The `ArgumentDefinition` interface now accepts:

- `validate` option: A function against which the values entered on the command line are validated; if validation fails, an error is thrown
- `validRange` option: An array of two integers representing the minimum and maximum allowable integers
- values of `stringArray` and `integerArray` as the value of `valueType`; if set to either of these values, the values entered will be converted to arrays

**Known issues**

Bad arguments entered for an `integerArray` are displayed as `NaN` in the error message