### PR TITLE
Display formatted usage help

### DIFF
--- a/.github/workflows/node-check-code.yaml
+++ b/.github/workflows/node-check-code.yaml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     timeout-minutes: 10
 

--- a/src/parseCliArgs/_types/index.ts
+++ b/src/parseCliArgs/_types/index.ts
@@ -13,7 +13,7 @@ export interface ArgumentDefV1 {
   required?: boolean;
   validate?: ValueValidator;
   validRange?: Integer[];
-  validValues?: ArgumentValue[];
+  validValues?: ReadonlyArray<ArgumentValue>;
   valueLabel?: string;
   valueType?: ValueType;
 }

--- a/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
+++ b/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
@@ -54,8 +54,8 @@ describe('formatArgsUse', () => {
       } as const,
     ];
     const expected = unindentBy(4)`
-      --stringArg a|b   string
-      --integerArg 1|2  integer
+      --stringArg=a|b   string
+      --integerArg=1|2  integer
     `;
 
     const actual = formatArgsUse(argDefs);
@@ -92,7 +92,7 @@ describe('formatArgsUse', () => {
       },
     ];
     const expected = unindentBy(4)`
-      --integerArg 1–100  integer
+      --integerArg=1–100  integer
     `;
 
     const actual = formatArgsUse(argDefs);

--- a/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
+++ b/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
@@ -32,8 +32,8 @@ describe('formatArgsUse', () => {
       },
     ];
     const expected = unindentBy(4)`
-      --stringArg   string
-      --integerArg  integer
+      --stringArg=<string>
+      --integerArg=<integer>
     `;
 
     const actual = formatArgsUse(argDefs);
@@ -54,8 +54,8 @@ describe('formatArgsUse', () => {
       } as const,
     ];
     const expected = unindentBy(4)`
-      --stringArg=a|b   string
-      --integerArg=1|2  integer
+      --stringArg=a|b
+      --integerArg=1|2
     `;
 
     const actual = formatArgsUse(argDefs);
@@ -72,11 +72,11 @@ describe('formatArgsUse', () => {
         name: 'integerArg',
         valueType: 'integer',
         valueLabel: 'description of the integer argument',
-      } as const,
+      },
     ];
     const expected = unindentBy(4)`
-      --stringArg   string
-      --integerArg  description of the integer argument
+      --stringArg=<string>
+      --integerArg=<integer>  description of the integer argument
     `;
 
     const actual = formatArgsUse(argDefs);

--- a/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
+++ b/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
@@ -98,4 +98,26 @@ describe('formatArgsUse', () => {
     const actual = formatArgsUse(argDefs);
     expect(actual).toBe(expected);
   });
+
+  it('should display the value range if defined', () => {
+    const argDefs: ArgumentDefinition[] = [
+      {
+        name: 'stringArrayArg',
+        validValues: ['a', 'b'],
+        valueType: 'stringArray',
+      },
+      {
+        name: 'integerArrayArg',
+        validRange: [1, 100],
+        valueType: 'integerArray',
+      },
+    ];
+    const expected = unindentBy(4)`
+      --stringArrayArg=(a|b)[]
+      --integerArrayArg=(1–100)[]  integerArray
+    `;
+
+    const actual = formatArgsUse(argDefs);
+    expect(actual).toBe(expected);
+  });
 });

--- a/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
+++ b/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
@@ -1,0 +1,37 @@
+import type { Integer } from '@skypilot/common-types';
+import { formatArgsUse } from '../formatArgsUse';
+
+function unindent(templateStringsArray: TemplateStringsArray, indentSize: Integer): string {
+  return templateStringsArray
+    .map(
+      block => block.split('\n').map(line => line.slice(indentSize)).join('\n')
+    )
+    .join('')
+    .split('\n')
+    .filter((line, index) => index > 0 || !!line)
+    .filter((line, index) => index < (line.length - 1) || !!line)
+    .join('\n');
+}
+
+function unindentBy(indentSize: Integer) {
+  return (templateStringsArray: TemplateStringsArray) => unindent(templateStringsArray, indentSize);
+}
+
+describe('formatArgsUse', () => {
+  it('should', () => {
+    const argDefs = [
+      {
+        name: 'sourceName',
+        valueType: 'string',
+        required: true,
+        validValues: ['a', 'b'],
+      } as const,
+    ];
+    const expected = unindentBy(4)`
+      --sourceName a|b
+    `;
+
+    const actual = formatArgsUse(argDefs);
+    expect(actual).toBe(expected);
+  });
+});

--- a/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
+++ b/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
@@ -1,4 +1,6 @@
 import type { Integer } from '@skypilot/common-types';
+
+import type { ArgumentDefinition } from '../../_types';
 import { formatArgsUse } from '../formatArgsUse';
 
 function unindent(templateStringsArray: TemplateStringsArray, indentSize: Integer): string {
@@ -18,17 +20,42 @@ function unindentBy(indentSize: Integer) {
 }
 
 describe('formatArgsUse', () => {
-  it('should', () => {
-    const argDefs = [
+  it('should list argument names in the left column and types in the right', () => {
+    const argDefs: ArgumentDefinition[] = [
       {
-        name: 'sourceName',
+        name: 'stringArg',
         valueType: 'string',
-        required: true,
+      },
+      {
+        name: 'integerArg',
+        valueType: 'integer',
+      },
+    ];
+    const expected = unindentBy(4)`
+      --stringArg   string
+      --integerArg  integer
+    `;
+
+    const actual = formatArgsUse(argDefs);
+    expect(actual).toBe(expected);
+  });
+
+  it('should display valid values if defined', () => {
+    const argDefs: ArgumentDefinition[] = [
+      {
+        name: 'stringArg',
+        valueType: 'string',
         validValues: ['a', 'b'],
+      },
+      {
+        name: 'integerArg',
+        valueType: 'integer',
+        validValues: [1, 2],
       } as const,
     ];
     const expected = unindentBy(4)`
-      --sourceName a|b
+      --stringArg a|b   string
+      --integerArg 1|2  integer
     `;
 
     const actual = formatArgsUse(argDefs);

--- a/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
+++ b/src/parseCliArgs/formatters/__tests__/formatArgsUse.unit.test.ts
@@ -61,4 +61,41 @@ describe('formatArgsUse', () => {
     const actual = formatArgsUse(argDefs);
     expect(actual).toBe(expected);
   });
+
+  it('should display a label if defined', () => {
+    const argDefs: ArgumentDefinition[] = [
+      {
+        name: 'stringArg',
+        valueType: 'string',
+      },
+      {
+        name: 'integerArg',
+        valueType: 'integer',
+        valueLabel: 'description of the integer argument',
+      } as const,
+    ];
+    const expected = unindentBy(4)`
+      --stringArg   string
+      --integerArg  description of the integer argument
+    `;
+
+    const actual = formatArgsUse(argDefs);
+    expect(actual).toBe(expected);
+  });
+
+  it('should display the value range if defined', () => {
+    const argDefs: ArgumentDefinition[] = [
+      {
+        name: 'integerArg',
+        validRange: [1, 100],
+        valueType: 'integer',
+      },
+    ];
+    const expected = unindentBy(4)`
+      --integerArg 1–100  integer
+    `;
+
+    const actual = formatArgsUse(argDefs);
+    expect(actual).toBe(expected);
+  });
 });

--- a/src/parseCliArgs/formatters/formatArgsUse.ts
+++ b/src/parseCliArgs/formatters/formatArgsUse.ts
@@ -1,6 +1,8 @@
 import type { Integer } from '@skypilot/common-types';
 import type { ArgumentDefinition } from '../_types';
 
+import { valueTypeIsArray } from '../valueTypeIsArray';
+
 function formatValidValues(validValues: ReadonlyArray<any> | undefined): string {
   if (!validValues) {
     return '';
@@ -23,14 +25,25 @@ function getNameWithValues(
   argDefinition: ArgumentDefinition,
 ): string {
   const { name, validRange, validValues, valueType } = argDefinition;
+  const separator = argDefinition.positional ? ': ' : '=';
   if (!validValues && !validRange) {
-    return `${name}=<${valueType}>`;
+    if (valueType === 'boolean') {
+      return name;
+    }
+    if (valueTypeIsArray(valueType)) {
+      return [name, `<${valueType.replace('Array', '')}[]>`].join(separator);
+    }
+    return [name, `<${valueType || 'any'}>`].join(separator);
   }
-  const formattedValidValues = validRange ? `${validRange[0]}–${validRange[1]}` : formatValidValues(validValues);
+  const formattedValidValues = ((): string => {
+    const isArrayType = valueTypeIsArray(valueType);
+    const formattedValues = validRange ? `${validRange[0]}–${validRange[1]}` : formatValidValues(validValues);
+    return isArrayType ? `(${formattedValues})[]` : formattedValues;
+  })();
   return [
     name,
     formattedValidValues,
-  ].join('=');
+  ].join(separator);
 }
 
 const gutterWidth = 2;
@@ -40,7 +53,7 @@ function formatArgUse(argDefinition: ArgumentDefinition, options: { leftColWidth
   const valueLabel = getValueLabel(argDefinition);
   return [
     ' '.repeat(leftIndentWidth),
-    '--',
+    argDefinition.positional ? '' : '--',
     getNameWithValues(argDefinition).padEnd(options.leftColWidth),
     ...(valueLabel ? [' '.repeat(gutterWidth), valueLabel] : []),
   ].join('').trimEnd();

--- a/src/parseCliArgs/formatters/formatArgsUse.ts
+++ b/src/parseCliArgs/formatters/formatArgsUse.ts
@@ -8,11 +8,23 @@ function formatValidValues(validValues: ReadonlyArray<any> | undefined): string 
   return validValues.join('|');
 }
 
-function toNameWithValues(
-  name: string, validRange: number[] | undefined, validValues: undefined | ReadonlyArray<any>
+function getValueLabel(argDefinition: ArgumentDefinition): string {
+  const { validRange, valueLabel, valueType } = argDefinition;
+  if (valueLabel) {
+    return valueLabel;
+  }
+  if (!validRange) {
+    return '';
+  }
+  return valueType || '';
+}
+
+function getNameWithValues(
+  argDefinition: ArgumentDefinition,
 ): string {
+  const { name, validRange, validValues, valueType } = argDefinition;
   if (!validValues && !validRange) {
-    return name;
+    return `${name}=<${valueType}>`;
   }
   const formattedValidValues = validRange ? `${validRange[0]}–${validRange[1]}` : formatValidValues(validValues);
   return [
@@ -25,19 +37,18 @@ const gutterWidth = 2;
 const leftIndentWidth = 2;
 
 function formatArgUse(argDefinition: ArgumentDefinition, options: { leftColWidth: Integer }): string {
-  const { name, valueLabel, validRange, validValues, valueType } = argDefinition;
+  const valueLabel = getValueLabel(argDefinition);
   return [
     ' '.repeat(leftIndentWidth),
     '--',
-    toNameWithValues(name, validRange, validValues).padEnd(options.leftColWidth),
-    ' '.repeat(gutterWidth),
-    valueLabel || valueType,
-  ].join('');
+    getNameWithValues(argDefinition).padEnd(options.leftColWidth),
+    ...(valueLabel ? [' '.repeat(gutterWidth), valueLabel] : []),
+  ].join('').trimEnd();
 }
 
 export function formatArgsUse(argDefinitions: ArgumentDefinition[]): string {
-  const namesWithValues = argDefinitions.map(({ name , validRange, validValues }) => [
-    toNameWithValues(name, validRange, validValues),
+  const namesWithValues = argDefinitions.map(argDefinition => [
+    getNameWithValues(argDefinition),
   ].join(' '));
   const leftColWidth = namesWithValues.reduce(
     (acc, nameWithValues) => Math.max(acc, nameWithValues.length),

--- a/src/parseCliArgs/formatters/formatArgsUse.ts
+++ b/src/parseCliArgs/formatters/formatArgsUse.ts
@@ -1,36 +1,49 @@
+import type { Integer } from '@skypilot/common-types';
 import type { ArgumentDefinition } from '../_types';
 
-function formatValidValues(validValues: ReadonlyArray<any>): string {
+function formatValidValues(validValues: ReadonlyArray<any> | undefined): string {
+  if (!validValues) {
+    return '';
+  }
   return validValues.join('|');
 }
 
-function toNameWithValues(name: string, validValues: undefined | ReadonlyArray<any>): string {
-  if (!validValues) {
+function toNameWithValues(
+  name: string, validRange: number[] | undefined, validValues: undefined | ReadonlyArray<any>
+): string {
+  if (!validValues && !validRange) {
     return name;
   }
+  const formattedValidValues = validRange ? `${validRange[0]}–${validRange[1]}` : formatValidValues(validValues);
   return [
     name,
-    ...(validValues ? [formatValidValues(validValues)] : []),
+    formattedValidValues,
   ].join(' ');
 }
 
 const gutterWidth = 2;
 const leftIndentWidth = 2;
 
+function formatArgUse(argDefinition: ArgumentDefinition, options: { leftColWidth: Integer }): string {
+  const { name, valueLabel, validRange, validValues, valueType } = argDefinition;
+  return [
+    ' '.repeat(leftIndentWidth),
+    '--',
+    toNameWithValues(name, validRange, validValues).padEnd(options.leftColWidth),
+    ' '.repeat(gutterWidth),
+    valueLabel || valueType,
+  ].join('');
+}
+
 export function formatArgsUse(argDefinitions: ArgumentDefinition[]): string {
-  const namesWithValues = argDefinitions.map(({ name , validValues }) => [
-    toNameWithValues(name, validValues),
+  const namesWithValues = argDefinitions.map(({ name , validRange, validValues }) => [
+    toNameWithValues(name, validRange, validValues),
   ].join(' '));
   const leftColWidth = namesWithValues.reduce(
     (acc, nameWithValues) => Math.max(acc, nameWithValues.length),
     0
   );
   return argDefinitions.map(
-    ({ name, valueLabel, validValues, valueType }) => [
-      ' '.repeat(leftIndentWidth),
-      '--',
-      toNameWithValues(name, validValues).padEnd(leftColWidth),
-      ' '.repeat(gutterWidth),
-      valueLabel || valueType,
-    ].join('')).join('\n');
+    argDefinition => formatArgUse(argDefinition, { leftColWidth })
+  ).join('\n');
 }

--- a/src/parseCliArgs/formatters/formatArgsUse.ts
+++ b/src/parseCliArgs/formatters/formatArgsUse.ts
@@ -1,0 +1,34 @@
+import type { ArgumentDefinition } from '../_types';
+
+function formatValidValues(validValues: ReadonlyArray<any>): string {
+  return validValues.join('|');
+}
+
+function toNameWithValues(name: string, validValues: undefined | ReadonlyArray<any>): string {
+  if (!validValues) {
+    return name;
+  }
+  return [
+    name,
+    ...(validValues ? [formatValidValues(validValues)] : []),
+  ].join(' ');
+}
+
+const leftIndentWidth = 2;
+
+export function formatArgsUse(argDefinitions: ArgumentDefinition[]): string {
+  const namesWithValues = argDefinitions.map(({ name , validValues }) => [
+    toNameWithValues(name, validValues),
+  ].join(' '));
+  const leftColWidth = namesWithValues.reduce(
+    (acc, nameWithValues) => Math.max(acc, nameWithValues.length),
+    0
+  );
+  return argDefinitions.map(
+    ({ name, valueLabel, validValues, valueType }) => [
+      ' '.repeat(leftIndentWidth),
+      '--',
+      toNameWithValues(name, validValues).padEnd(leftColWidth),
+      ...(valueLabel ? ['  ', valueLabel] : []),
+    ].join('')).join('\n');
+}

--- a/src/parseCliArgs/formatters/formatArgsUse.ts
+++ b/src/parseCliArgs/formatters/formatArgsUse.ts
@@ -18,7 +18,7 @@ function toNameWithValues(
   return [
     name,
     formattedValidValues,
-  ].join(' ');
+  ].join('=');
 }
 
 const gutterWidth = 2;

--- a/src/parseCliArgs/formatters/formatArgsUse.ts
+++ b/src/parseCliArgs/formatters/formatArgsUse.ts
@@ -14,6 +14,7 @@ function toNameWithValues(name: string, validValues: undefined | ReadonlyArray<a
   ].join(' ');
 }
 
+const gutterWidth = 2;
 const leftIndentWidth = 2;
 
 export function formatArgsUse(argDefinitions: ArgumentDefinition[]): string {
@@ -29,6 +30,7 @@ export function formatArgsUse(argDefinitions: ArgumentDefinition[]): string {
       ' '.repeat(leftIndentWidth),
       '--',
       toNameWithValues(name, validValues).padEnd(leftColWidth),
-      ...(valueLabel ? ['  ', valueLabel] : []),
+      ' '.repeat(gutterWidth),
+      valueLabel || valueType,
     ].join('')).join('\n');
 }

--- a/src/parseCliArgs/valueTypeIsArray.ts
+++ b/src/parseCliArgs/valueTypeIsArray.ts
@@ -1,0 +1,8 @@
+import { ValueType } from './_types';
+
+export function valueTypeIsArray(valueType: ValueType | undefined): valueType is 'integerArray' | 'stringArray' {
+  if (!valueType) {
+    return false;
+  }
+  return ['integerArray', 'stringArray'].includes(valueType);
+}

--- a/src/scripts/parse-args.ts
+++ b/src/scripts/parse-args.ts
@@ -2,13 +2,69 @@ import { parseCliArgs } from '../parseCliArgs';
 
 const parsedArgs = parseCliArgs({
   named: [
-    { name: 'myNamedArg', aliases:  ['n'] },
-    { name: 'verbose', valueType: 'boolean' },
-    { name: 'int', valueType: 'integerArray', validRange: [1,2] },
-    { name: 'str', valueType: 'stringArray' },
+    {
+      name: 'sourceName',
+      valueType: 'string',
+      required: true,
+      validValues: ['graphqlapi', 'restapi', 'database'],
+    },
+    {
+      name: 'pageRange',
+      valueType: 'integerArray',
+      valueLabel: 'numbers of the first and last pages to fetch',
+    },
+    {
+      name: 'refetch',
+      valueType: 'boolean',
+      defaultValue: false,
+      valueLabel: 'fetch even if the record is already in the database',
+    },
+    {
+      name: 'slice',
+      valueType: 'integerArray',
+      valueLabel: 'slice to apply to the list of records to fetch',
+    },
+    {
+      name: 'verbose',
+      valueType: 'boolean',
+      defaultValue: true,
+      valueLabel: 'display console messages during the request run',
+    },
+    {
+      name: 'localeCode',
+      valueType: 'string',
+      valueLabel: 'locale code to pass to the request',
+    },
+    // Database options
+    {
+      name: 'noBackup',
+      valueType: 'boolean',
+      defaultValue: false,
+      valueLabel: 'do not back up the database when starting a request run',
+    },
+    {
+      name: 'wipeData',
+      valueType: 'boolean',
+      defaultValue: false,
+      valueLabel: 'wipe the database when starting the run',
+    },
+    // Browser options
+    {
+      name: 'delayInMs',
+      valueType: 'integer',
+      defaultValue: 100,
+      valueLabel: 'delay between requests',
+    },
+    {
+      name: 'variableDelayInMs',
+      valueType: 'integer',
+      defaultValue: 100,
+      valueLabel: 'additional variable delay (from 1 to entered range) between requests',
+    },
   ],
   positional: [
-    { name: 'positional' },
+    { name: 'file1' },
+    { name: 'file2' },
   ],
 }, { echo: { echoIf: argsMap => argsMap.get('verbose') } });
 


### PR DESCRIPTION
BREAKING CHANGES:
- Dropped explicit support for Node v10. It is likely that the library will continue to work normally under v10, but tests will no longer be run against it.

Features:
- Improved the formatting of the help text