### PR TITLE
fix: Valid integer & string array definitions are disallowed

### DIFF
--- a/src/parseCliArgs/validators/__tests__/disallowWrongTypeDefault.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/disallowWrongTypeDefault.unit.test.ts
@@ -1,4 +1,4 @@
-import { ArgumentDefinition, ValidationException } from '../../_types';
+import type { ArgumentDefinition, ValidationException } from '../../_types';
 import { disallowWrongTypeDefault } from '../disallowWrongTypeDefault';
 
 
@@ -22,6 +22,8 @@ describe('disallowWrongTypeDefault()', () => {
       { name: 'option2', defaultValue: 1, valueType: 'integer' },
       { name: 'option3', defaultValue: 1.2, valueType: 'number' },
       { name: 'option4', defaultValue: 'value', valueType: 'string' },
+      { name: 'option5', defaultValue: [1, 2], valueType: 'integerArray' },
+      { name: 'option6', defaultValue: ['a', 'b'], valueType: 'stringArray' },
     ];
 
     const exceptions = disallowWrongTypeDefault(argDefs);
@@ -36,6 +38,8 @@ describe('disallowWrongTypeDefault()', () => {
       { name: 'integerOpt', defaultValue: 0.1, valueType: 'integer' },
       { name: 'numberOpt', defaultValue: true, valueType: 'number' },
       { name: 'stringOpt', defaultValue: 0, valueType: 'string' },
+      { name: 'integerArrayOpt', defaultValue: 1, valueType: 'integerArray' },
+      { name: 'stringArrayOpt', defaultValue: 'value', valueType: 'stringArray' },
     ];
     const exceptions = disallowWrongTypeDefault(argDefs);
 
@@ -63,6 +67,18 @@ describe('disallowWrongTypeDefault()', () => {
         level: 'error',
         message: 'Bad definition for stringOpt: The default value is not of string type',
         identifiers: ['stringOpt'],
+      },
+      {
+        code: 'badDefinition',
+        level: 'error',
+        message: 'Bad definition for integerArrayOpt: The default value is not an integer array',
+        identifiers: ['integerArrayOpt'],
+      },
+      {
+        code: 'badDefinition',
+        level: 'error',
+        message: 'Bad definition for stringArrayOpt: The default value is not a string array',
+        identifiers: ['stringArrayOpt'],
       },
     ];
 

--- a/src/parseCliArgs/validators/__tests__/disallowWrongTypeListed.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/disallowWrongTypeListed.unit.test.ts
@@ -1,4 +1,4 @@
-import { ArgumentDefinition, ValidationException } from '../../_types';
+import type { ArgumentDefinition, ValidationException } from '../../_types';
 import { disallowWrongTypeListed } from '../disallowWrongTypeListed';
 
 
@@ -22,6 +22,8 @@ describe('disallowWrongTypeListed()', () => {
       { name: 'option2', validValues: [1], valueType: 'integer' },
       { name: 'option3', validValues: [1.2], valueType: 'number' },
       { name: 'option4', validValues: ['value'], valueType: 'string' },
+      { name: 'option5', validValues: [1, 2], valueType: 'integerArray' },
+      { name: 'option6', validValues: ['a', 'b'], valueType: 'stringArray' },
     ];
 
     const exceptions = disallowWrongTypeListed(argDefs);
@@ -36,6 +38,8 @@ describe('disallowWrongTypeListed()', () => {
       { name: 'integerOpt', validValues: [0, 1.1], valueType: 'integer' },
       { name: 'numberOpt', validValues: [1.1, true], valueType: 'number' },
       { name: 'stringOpt', validValues: ['value', 0], valueType: 'string' },
+      { name: 'integerArrayOpt', validValues: ['value', 0], valueType: 'integerArray' },
+      { name: 'stringArrayOpt', validValues: ['value', 0], valueType: 'stringArray' },
     ];
     const exceptions = disallowWrongTypeListed(argDefs);
 
@@ -63,6 +67,18 @@ describe('disallowWrongTypeListed()', () => {
         level: 'error',
         message: 'Bad definition for stringOpt: validValues must be of string type',
         identifiers: ['stringOpt'],
+      },
+      {
+        code: 'badDefinition',
+        level: 'error',
+        message: 'Bad definition for integerArrayOpt: validValues must be of integer type',
+        identifiers: ['integerArrayOpt'],
+      },
+      {
+        code: 'badDefinition',
+        level: 'error',
+        message: 'Bad definition for stringArrayOpt: validValues must be of string type',
+        identifiers: ['stringArrayOpt'],
       },
     ];
 

--- a/src/parseCliArgs/validators/disallowWrongTypeDefault.ts
+++ b/src/parseCliArgs/validators/disallowWrongTypeDefault.ts
@@ -6,15 +6,28 @@ export function disallowWrongTypeDefault(
 ): ValidationException[] {
   return argDefs.reduce((accExceptions, argDef) => {
     const { defaultValue, name, valueType } = argDef;
+
     if (defaultValue === undefined || valueType === undefined || hasCorrectType(valueType, defaultValue)) {
       return accExceptions;
     }
+
+    const typeDescription = (() => {
+      switch (valueType) {
+        case 'stringArray':
+          return 'a string array';
+        case 'integerArray':
+          return 'an integer array';
+        default:
+          return `of ${valueType} type`;
+      }
+    })();
+
     return [
       ...accExceptions,
       {
         code: 'badDefinition',
         level: 'error',
-        message: `Bad definition for ${name}: The default value is not of ${valueType} type`,
+        message: `Bad definition for ${name}: The default value is not ${typeDescription}`,
         identifiers: [name],
       },
     ];

--- a/src/parseCliArgs/validators/disallowWrongTypeListed.ts
+++ b/src/parseCliArgs/validators/disallowWrongTypeListed.ts
@@ -1,24 +1,28 @@
-import { ArgumentDefinition, ValidationException } from '../_types';
+import type { ArgumentDefinition, ValidationException } from '../_types';
 import { hasCorrectType } from './hasCorrectType';
+import { parseBaseType } from './parseBaseType';
 
 export function disallowWrongTypeListed(
   argDefs: ArgumentDefinition[]
 ): ValidationException[] {
   return argDefs.reduce((accExceptions, argDef) => {
     const { name, validValues, valueType } = argDef;
-    if (
-      validValues === undefined
-      || valueType === undefined
-      || validValues.every(value => hasCorrectType(valueType, value))
-    ) {
+
+    if (typeof validValues === 'undefined' || typeof valueType === 'undefined') {
       return accExceptions;
     }
+
+    const baseType = parseBaseType(valueType);
+    if (validValues.every(value => hasCorrectType(baseType, value))) {
+      return accExceptions;
+    }
+
     return [
       ...accExceptions,
       {
         code: 'badDefinition',
         level: 'error',
-        message: `Bad definition for ${name}: validValues must be of ${valueType} type`,
+        message: `Bad definition for ${name}: validValues must be of ${baseType} type`,
         identifiers: [name],
       },
     ];

--- a/src/parseCliArgs/validators/parseBaseType.ts
+++ b/src/parseCliArgs/validators/parseBaseType.ts
@@ -1,0 +1,8 @@
+import { ValueType } from '../_types';
+
+export function parseBaseType(valueType: ValueType): ValueType {
+  if (['integerArray', 'stringArray'].includes(valueType)) {
+    return valueType.replace('Array', '') as ValueType;
+  }
+  return valueType;
+}


### PR DESCRIPTION
Fixes the validation of `defaultValue` & `validValues` for array types (`integerArray` and `stringArray`).
