### PR TITLE
Feature: Optionally display a description in the help text

### DIFF
--- a/src/parseCliArgs/index.ts
+++ b/src/parseCliArgs/index.ts
@@ -46,6 +46,7 @@ interface ParseCliArgsOptions {
   apiVersion?: Integer;
   args?: string[]; // arguments explicitly passed in instead of parsed from the command line
   echo?: boolean | EchoOptions;
+  description?: string;
   exitProcessWhenTesting?: boolean;
   isTest?: boolean;
   mapAllNamedArgs?: boolean;
@@ -62,6 +63,7 @@ export function parseCliArgs(
 
   const {
     args = process.argv.slice(2),
+    description,
     echo,
     exitProcessWhenTesting = false,
     mapAllNamedArgs = false,
@@ -109,6 +111,7 @@ export function parseCliArgs(
     showUsage({
       argsMap,
       command: scriptName,
+      description,
       exitCode: 0,
       exitProcessWhenTesting,
     });
@@ -120,6 +123,7 @@ export function parseCliArgs(
     showUsage({
       argsMap,
       command: scriptName,
+      description,
       exceptions: argumentExceptions,
       exitCode: 1,
       exitProcessWhenTesting,
@@ -132,11 +136,14 @@ export function parseCliArgs(
   const { echoUndefined, shouldEcho } = toEchoParams(argValuesMap, echo);
   if (shouldEcho) {
     const unnamedPositionalArgs = positionalArgs.slice(positionalArgDefInputs.length);
-    console.log(formatArgsForEcho(
-      argValuesMap,
-      unnamedPositionalArgs,
-      { echoUndefined }
-    ).join('\n'));
+    console.log([
+      ...(description ? [description].flat() : []),
+      ...formatArgsForEcho(
+        argValuesMap,
+        unnamedPositionalArgs,
+        { echoUndefined }
+      ),
+    ].join('\n'));
   }
 
   return {

--- a/src/parseCliArgs/mapArgs.ts
+++ b/src/parseCliArgs/mapArgs.ts
@@ -44,7 +44,6 @@ export function mapArgs(
       const enteredValue = getOrDefault(initialParsedArgs, name, undefined);
       switch (valueType) {
         case 'stringArray':
-          console.log('enteredValue:', enteredValue);
           return typeof enteredValue === 'undefined' ? undefined
             : typeof enteredValue === 'string' ? enteredValue.split(',')
               : [`${enteredValue}`];

--- a/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/validateConstrainedArgs.unit.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable quotes */
+
 import type { Argument, ValidationException } from 'src/parseCliArgs/_types';
 import { validateConstrainedArgs } from '../validateConstrainedArgs';
 
@@ -53,13 +55,13 @@ describe('validateConstrainedArgs()', () => {
       {
         code: 'unlistedValue',
         level: 'error',
-        message: "Invalid value 3 for 'con1'. Allowed values: 1, 2",
+        message: "Invalid value 3 for 'con1'. Allowed values: 1|2",
         identifiers: ['con1'],
       },
       {
         code: 'unlistedValue',
         level: 'error',
-        message: "Invalid value 1 for 'con3'. Allowed values: 'a', 'b'",
+        message: `Invalid value 1 for 'con3'. Allowed values: "a"|"b"`,
         identifiers: ['con3'],
       },
       {

--- a/src/parseCliArgs/validators/__tests__/validateConstrainedValue.unit.test.ts
+++ b/src/parseCliArgs/validators/__tests__/validateConstrainedValue.unit.test.ts
@@ -51,7 +51,7 @@ describe('validateConstrainedValue(value, :ArgumentDef)', () => {
     values.forEach((value) => {
       const exceptions: ValidationException[] = validateConstrainedValue(value, argDef);
       if (exceptions.length < 1) {
-        console.log(`invalidValue: ${value}`);
+        console.warn(`invalidValue: ${value}`);
       }
       expect(exceptions).toHaveLength(1);
     });

--- a/src/scripts/parse-args.ts
+++ b/src/scripts/parse-args.ts
@@ -31,9 +31,10 @@ const parsedArgs = parseCliArgs({
       valueLabel: 'display console messages during the request run',
     },
     {
-      name: 'localeCode',
-      valueType: 'string',
-      valueLabel: 'locale code to pass to the request',
+      name: 'localeCodes',
+      valueType: 'stringArray',
+      valueLabel: 'locale codes to pass to the request',
+      validValues: ['en', 'fr'],
     },
     // Database options
     {

--- a/src/scripts/parse-args.ts
+++ b/src/scripts/parse-args.ts
@@ -66,6 +66,9 @@ const parsedArgs = parseCliArgs({
     { name: 'file1' },
     { name: 'file2' },
   ],
-}, { echo: { echoIf: argsMap => argsMap.get('verbose') } });
+}, {
+  description: 'Sample script',
+  echo: { echoIf: argsMap => argsMap.get('verbose') },
+});
 
 console.log('parsedArgs:', parsedArgs);


### PR DESCRIPTION
## Features

- `parseCliArgs` now accepts a `description` option. If provided, it will be displayed as the first line of the help text
- The formatting of help text has been improved